### PR TITLE
fix(docs): Fix redirect_url example

### DIFF
--- a/docs/content/doc/setup/openid-examples.md
+++ b/docs/content/doc/setup/openid-examples.md
@@ -37,7 +37,7 @@ Authelia config:
 description: Vikunja
 secret: <vikunja secret>
 redirect_uris:
-  - https://vikunja.mydomain.com/auth/openid/    <----- Matching slash at the end
+  - https://vikunja.mydomain.com/auth/openid/authelia
 scopes:
   - openid
   - email


### PR DESCRIPTION
Hey,

we just setup a Vikunja connected to Authelia and I was very pleased to see that there is an example for exact this usecase but we discovered a small mistake in the example. According to [this line](https://github.com/go-vikunja/api/blob/54b7f7127cb5aa5aba6a97798685efb59ac8ca83/pkg/modules/auth/openid/providers.go#L145) (and to our experience :D) the name of the provider from the config gets appended to the redirect_url therefore the example won't work like it was in the docs.

Best,
Felix
