### PR TITLE
fix(mailer): forcessl config

### DIFF
--- a/pkg/mail/mail.go
+++ b/pkg/mail/mail.go
@@ -58,6 +58,10 @@ func getClient() (*mail.Client, error) {
 		mail.WithTimeout((config.MailerQueueTimeout.GetDuration() + 3) * time.Second), // 3s more for us to close before mail server timeout
 	}
 
+	if config.MailerForceSSL.GetBool() {
+		opts = append(opts, mail.WithSSL())
+	}
+
 	if config.MailerUsername.GetString() != "" && config.MailerPassword.GetString() != "" {
 		opts = append(opts, mail.WithSMTPAuth(authType))
 	}


### PR DESCRIPTION
1. add ssl setting into mail client.

I have tested the following mail service providers, all can be used.(port 465)

- gmail
- alibaba exchange mail
- tencent exchange mail

In gmail should  use [App Password](https://support.google.com/accounts/answer/185833?hl=en) to setup the vikunja config.