### PR TITLE
WIP: fix(background): when list background is removed, delete file from file system and DB

### DIFF
--- a/pkg/db/fixtures/lists.yml
+++ b/pkg/db/fixtures/lists.yml
@@ -242,3 +242,14 @@
   position: 7
   updated: 2018-12-02 15:13:12
   created: 2018-12-01 15:13:12
+-
+  id: 25
+  title: Test25 with background
+  description: Lorem Ipsum
+  identifier: test6
+  owner_id: 6
+  namespace_id: 6
+  background_file_id: 1
+  position: 8
+  updated: 2018-12-02 15:13:12
+  created: 2018-12-01 15:13:12

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -140,7 +140,7 @@ func (f *File) Delete() (err error) {
 		var perr *os.PathError
 		if errors.As(err, &perr) {
 			// Don't fail when removing the file failed
-			log.Errorf("Error deleting file %d: %w", err)
+			log.Errorf("Error deleting file %d: %w", f.ID, err)
 			return s.Commit()
 		}
 

--- a/pkg/modules/background/handler/background.go
+++ b/pkg/modules/background/handler/background.go
@@ -331,6 +331,11 @@ func RemoveListBackground(c echo.Context) error {
 		return err
 	}
 
+	err = list.DeleteBackgroundFileIfExists()
+	if err != nil {
+		return err
+	}
+
 	list.BackgroundFileID = 0
 	list.BackgroundInformation = nil
 	list.BackgroundBlurHash = ""

--- a/pkg/modules/background/upload/upload.go
+++ b/pkg/modules/background/upload/upload.go
@@ -54,11 +54,9 @@ func (p *Provider) Search(s *xorm.Session, search string, page int64) (result []
 // @Router /lists/{id}/backgrounds/upload [put]
 func (p *Provider) Set(s *xorm.Session, img *background.Image, list *models.List, auth web.Auth) (err error) {
 	// Remove the old background if one exists
-	if list.BackgroundFileID != 0 {
-		file := files.File{ID: list.BackgroundFileID}
-		if err := file.Delete(); err != nil {
-			return err
-		}
+	err = list.DeleteBackgroundFileIfExists()
+	if err != nil {
+		return err
 	}
 
 	file := &files.File{}


### PR DESCRIPTION
Currently, if a list background is removed, the background file stays in disk and in the DB forever.

Fix this by deleting the file during background removal, similar to how it's done when a new background is uploaded.

Test Plan:
A) Before these changes
A.1) Create a new list
A.2) Set a new background to the list
A.3) Check file is in disk and DB:
```
$ ls files/
1

$ sqlite3 vikunja.db
SQLite version 3.40.1 2022-12-28 14:03:47
Enter ".help" for usage hints.
sqlite> select * from files;
1|20220410_180833.jpg||2822966|2023-01-25 21:25:28|1
sqlite> select * from lists;
1|Teste||||1|1|0|1|LeGlCmIqR*of_4R+WCoe4;s.oLjZ|65536.0|2023-01-25 21:25:21|2023-01-25 21:25:28
```

A.4) Remove background from list
A.5) Check file is still in disk and DB:
```
$ ls files/
1

$ sqlite3 vikunja.db
SQLite version 3.40.1 2022-12-28 14:03:47
Enter ".help" for usage hints.
sqlite> select * from files;
1|20220410_180833.jpg||2822966|2023-01-25 21:25:28|1
sqlite> select * from lists;
1|Teste||||1|1|0|0||65536.0|2023-01-25 21:25:21|2023-01-25 21:32:39
```

B) After these changes
B.1) Set background again
B.2) Check files in disk and DB:
```
$ ls files/
1 2

$ sqlite3 vikunja.db
SQLite version 3.40.1 2022-12-28 14:03:47
Enter ".help" for usage hints.
sqlite> select * from files;
1|20220410_180833.jpg||2822966|2023-01-25 21:25:28|1
2|20220410_180833.jpg||2822966|2023-01-25 21:34:33|1
sqlite> select * from lists;
1|Teste||||1|1|0|2|LeGlCmIqR*of_4R+WCoe4;s.oLjZ|65536.0|2023-01-25 21:25:21|2023-01-25 21:34:33
```

B.3) Remove background image
B.4) Check files and DB again, verify image 2 has been deleted:
```
$ ls files/
1

$ sqlite3 vikunja.db
SQLite version 3.40.1 2022-12-28 14:03:47
Enter ".help" for usage hints.
sqlite> select * from files;
1|20220410_180833.jpg||2822966|2023-01-25 21:25:28|1
sqlite> select * from lists;
1|Teste||||1|1|0|0||65536.0|2023-01-25 21:25:21|2023-01-25 21:36:13
```

C) Run unit tests:
```
$ mage test:unit

...

=== RUN   TestList_DeleteBackgroundFileIfExists
=== RUN   TestList_DeleteBackgroundFileIfExists/list_with_background
=== RUN   TestList_DeleteBackgroundFileIfExists/list_with_invalid_background
=== RUN   TestList_DeleteBackgroundFileIfExists/list_without_background
--- PASS: TestList_DeleteBackgroundFileIfExists (0.01s)
    --- PASS: TestList_DeleteBackgroundFileIfExists/list_with_background (0.00s)
    --- PASS: TestList_DeleteBackgroundFileIfExists/list_with_invalid_background (0.00s)
    --- PASS: TestList_DeleteBackgroundFileIfExists/list_without_background (0.00s)

...

```