### PR TITLE
fix(docs): fix traefik v2 example

### DIFF
--- a/docs/content/doc/setup/full-docker-example.md
+++ b/docs/content/doc/setup/full-docker-example.md
@@ -155,7 +155,7 @@ services:
     restart: unless-stopped
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.vikunja-api.rule=Host(`vikunja.example.com`) && PathPrefix(`/api/v1`, `/dav/`, `/.well-known/`)"
+      - "traefik.http.routers.vikunja-api.rule=Host(`vikunja.example.com`) && (PathPrefix(`/api/v1`) || PathPrefix(`/dav/`) || PathPrefix(`/.well-known/`))"
       - "traefik.http.routers.vikunja-api.entrypoints=https"
       - "traefik.http.routers.vikunja-api.tls.certResolver=acme"
   frontend:


### PR DESCRIPTION
The example from the docs lead to the following error in Traefik logs:

	ERR error="unexpected number of parameters; got 3, expected one of [1]"

Related discussion: https://community.vikunja.io/t/error-405-when-creating-a-user/928