### PR TITLE
Fixed an issue that could cause the api service to exit(1) when using the default documented docker-compose.yml file

### DIFF
--- a/docs/content/doc/setup/install-backend.md
+++ b/docs/content/doc/setup/install-backend.md
@@ -153,7 +153,7 @@ services:
     volumes:
       - ./files:/app/vikunja/files
 		depends_on:
-      db:
+    db:
           condition: service_healthy
   db:
     image: mariadb:10
@@ -165,7 +165,7 @@ services:
       MYSQL_DATABASE: vikunja
     volumes:
       - ./db:/var/lib/mysql
-		healthcheck:
+    healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 30s
       retries: 10

--- a/docs/content/doc/setup/install-backend.md
+++ b/docs/content/doc/setup/install-backend.md
@@ -152,6 +152,9 @@ services:
       VIKUNJA_SERVICE_FRONTENDURL: https://<your public frontend url with slash>/
     volumes:
       - ./files:/app/vikunja/files
+		depends_on:
+      db:
+          condition: service_healthy
   db:
     image: mariadb:10
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
@@ -162,6 +165,11 @@ services:
       MYSQL_DATABASE: vikunja
     volumes:
       - ./db:/var/lib/mysql
+		healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 30s
+      retries: 10
+
 {{< /highlight >}}
 
 See [full docker example]({{< ref "full-docker-example.md">}}) for more variations of this config.


### PR DESCRIPTION
It is possible for the api service to crash due to being unable to connect to the database which is not yet ready to accept connections. I added a healthcheck for the db and added a condition for the api service to wait until the db service is healthy